### PR TITLE
Feat #17 introduce v1 with admin routes and redirects

### DIFF
--- a/cmd/api/server/server.go
+++ b/cmd/api/server/server.go
@@ -1,18 +1,11 @@
 package server
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
-	"os"
 	"time"
 
-	"github.com/amorindev/go-tmpl/internal/config"
-	mongoClient "github.com/amorindev/go-tmpl/internal/mongo"
-	"github.com/amorindev/go-tmpl/pkg/app/admin/api/handler"
-	authMethodHandler "github.com/amorindev/go-tmpl/pkg/app/auth-methods/handler"
-	authMethodService "github.com/amorindev/go-tmpl/pkg/app/auth-methods/service"
-	userRepository "github.com/amorindev/go-tmpl/pkg/app/users/repository/mongo"
+	v1 "github.com/amorindev/go-tmpl/cmd/api/server/v1"
 )
 
 type HttpServer struct {
@@ -20,63 +13,11 @@ type HttpServer struct {
 }
 
 func NewHttpServer(port string) *HttpServer {
-	mux := http.NewServeMux()
-
-	appEnvs := config.Load()
-
-	// * MongoDB
-	dbURI := os.Getenv("MONGO_DB_URI")
-	if dbURI == "" {
-		log.Fatal("missing required environment variable: MONGO_DB_URI")
-	}
-
-	dbName := os.Getenv("MONGO_INITDB_DATABASE")
-	if dbName == "" {
-		log.Fatal("missing required environment variable: DB_NAME")
-	}
-
-	mongoConn := mongoClient.New(dbURI)
-	mongoDB := mongoConn.DB.Database(dbName)
-	mongoConn.Ping()
-
-	// * Collections
-	userColl := mongoDB.Collection("users")
-
-	// * Repositories and indexes
-	userRepo := userRepository.NewUserRepo(mongoConn.DB, userColl)
-
-	// * Indexes
-	err := userRepo.CreateIndexes()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// * Services
-	authMethodSrv := authMethodService.NewAuthMethodSrv(userRepo)
-
-	// * Handler
-	authMethodHandler.NewAuthMethodHandler(mux, authMethodSrv)
-
-	mux.HandleFunc("GET /ping", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		resp := struct {
-			Msg string `json:"msg"`
-		}{
-			Msg: "pong",
-		}
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(resp)
-	})
-
-	mux.HandleFunc("/admin", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/admin/home", http.StatusFound)
-	})
-
-	handler.NewAdminHandler(mux, appEnvs.ApiBaseUrl)
+	apiV1 := v1.New()
 
 	server := &http.Server{
 		Addr:         ":" + port,
-		Handler:      mux,
+		Handler:      apiV1,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}

--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -1,0 +1,69 @@
+package v1
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/internal/config"
+	mongoClient "github.com/amorindev/go-tmpl/internal/mongo"
+	"github.com/amorindev/go-tmpl/pkg/app/admin/api/handler"
+	authMethodHandler "github.com/amorindev/go-tmpl/pkg/app/auth-methods/handler"
+	authMethodService "github.com/amorindev/go-tmpl/pkg/app/auth-methods/service"
+	userRepository "github.com/amorindev/go-tmpl/pkg/app/users/repository/mongo"
+)
+
+func New() http.Handler {
+	mux := http.NewServeMux()
+
+	// Api version
+	v1 := http.NewServeMux()
+	mux.Handle("/v1/", http.StripPrefix("/v1", v1))
+
+	appEnvs := config.Load()
+
+	// MongoDB
+	mongoConn := mongoClient.New(appEnvs.MongoDBUri)
+	mongoDB := mongoConn.DB.Database(appEnvs.MongoInitDB)
+	mongoConn.Ping()
+
+	// Collections
+	userColl := mongoDB.Collection("users")
+
+	// Repositories
+	userRepo := userRepository.NewUserRepo(mongoConn.DB, userColl)
+
+	// Indexes
+	err := userRepo.CreateIndexes()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Services
+	authMethodSrv := authMethodService.NewAuthMethodSrv(userRepo)
+
+	// Handler
+	// Note: all subsequent handlers should also be registered using v1
+	authMethodHandler.NewAuthMethodHandler(v1, authMethodSrv)
+
+	mux.HandleFunc("GET /ping", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := struct {
+			Msg string `json:"msg"`
+		}{
+			Msg: "pong",
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	// Templates
+	// Redirects requests from "/admin" to the admin home page under API v1
+	mux.HandleFunc("/admin", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/v1/admin/home", http.StatusFound)
+	})
+
+	handler.NewAdminHandler(v1, appEnvs.ApiBaseUrl)
+
+	return mux
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,10 @@ import (
 )
 
 type Config struct {
+	// MongoDB
+	MongoDBUri  string
+	MongoInitDB string
+
 	// Jwt
 	JWTAccessSecret           string
 	JWTRefreshSecret          string
@@ -24,6 +28,10 @@ type Config struct {
 }
 
 func Load() *Config {
+	// Mongo DB
+	mongoInitDB := cmp.Or(os.Getenv("MONGO_INITDB_DATABASE"), "auth-tmpl")
+
+	// Auth - tokens
 	accessExp := cmp.Or(os.Getenv("JWT_ACCESS_EXP_IN"), "15m")
 	refreshExp := cmp.Or(os.Getenv("JWT_REFRESH_EXP_IN"), "168h")
 	refreshExpRememberMe := cmp.Or(os.Getenv("JWT_REFRESH_EXP_IN_REMEMBER"), "720h")
@@ -43,10 +51,13 @@ func Load() *Config {
 		log.Fatalf("Invalid JWT_REFRESH_EXP_IN_REMEMBER format: %v", err)
 	}
 
+	// App
 	port := cmp.Or(os.Getenv("HTTP_SERVER_PORT"), "8000")
 	apiBaseUrl := cmp.Or(os.Getenv("API_BASE_URL"), "http://localhost:"+port)
 
 	return &Config{
+		MongoDBUri:                mustGetEnv("MONGO_DB_URI"),
+		MongoInitDB:               mongoInitDB,
 		JWTAccessSecret:           mustGetEnv("JWT_ACCESS_TOKEN"),
 		JWTRefreshSecret:          mustGetEnv("JWT_REFRESH_TOKEN"),
 		JWTIssuer:                 mustGetEnv("JWT_ISS"),

--- a/pkg/app/admin/api/web/templates/base.html
+++ b/pkg/app/admin/api/web/templates/base.html
@@ -95,8 +95,8 @@
       <div class="sidebar">
         <h1>Admin Panel</h1>
         <nav>
-          <a href="/admin/home" class="{{if eq .ActivePage "home"}}active{{end}}">Home</a>
-          <a href="/admin/other" class="{{if eq .ActivePage "other"}}active{{end}}">Other</a>
+          <a href="/v1/admin/home" class="{{if eq .ActivePage "home"}}active{{end}}">Home</a>
+          <a href="/v1/admin/other" class="{{if eq .ActivePage "other"}}active{{end}}">Other</a>
         </nav>
       </div>
       <div class="main">


### PR DESCRIPTION
Description:
This PR adds support for API version v1 and sets up the initial admin functionality:
- Mounted routes under /v1/.
- Added redirect from /admin to /v1/admin/home.
- Updated sidebar to use /v1/admin links with active page state.
- Integrated admin handler with app configuration.

<img width="934" height="436" alt="image" src="https://github.com/user-attachments/assets/0c45e186-2674-4deb-8e71-a49f884f89c3" />

<img width="1366" height="175" alt="image" src="https://github.com/user-attachments/assets/015aee34-510f-4eb8-b373-0c49adef24e8" />

Close #17 
