### PR TITLE
chore: add Makefile with .env support for run and compose-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+include .env
+
+run:
+	@go run main.go
+
+compose-dev:
+	@docker-compose -f docker-compose.dev.yml --env-file .env up


### PR DESCRIPTION
Adds a Makefile to simplify local development with commands to run the app and start docker-compose.
