### PR TITLE
Refactor: move hashPassword method from user to internal/encryption

### DIFF
--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -8,6 +8,17 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// HashPassword takes a plain-text password and returns its hashed version
+// using bcrypt. It uses bcrypt.DefaultCost as the cost factor.
+// Returns the hash as a string and an error if hashing fails.
+func HashPassword(password string) (string, error) {
+	hashPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash password %w", err)
+	}
+	return string(hashPassword), nil
+}
+
 // CheckPassword compares a plain-text password with its hashed value.
 // Returns nil if they match, or an error if they do not match or if
 // verification fails.

--- a/pkg/app/auth-methods/domain/domain.user.password.auth.go
+++ b/pkg/app/auth-methods/domain/domain.user.password.auth.go
@@ -1,10 +1,7 @@
 package domain
 
 import (
-	"fmt"
 	"time"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 // UserPasswordAuth stores password authentication data.
@@ -13,14 +10,4 @@ type UserPasswordAuth struct {
 	PasswordHash string     `bson:"password_hash"`
 	CreatedAt    *time.Time `bson:"created_at"`
 	UpdatedAt    *time.Time `bson:"updated_at"`
-}
-
-// HashPassword hashes the plain password and stores it in PasswordHash.
-func (upa *UserPasswordAuth) HashPassword() error {
-	passwordHash, err := bcrypt.GenerateFromPassword([]byte(upa.Password), bcrypt.DefaultCost)
-	if err != nil {
-		return fmt.Errorf("error hashing password: %w", err)
-	}
-	upa.PasswordHash = string(passwordHash)
-	return nil
 }

--- a/pkg/app/auth-methods/service/sign.up.go
+++ b/pkg/app/auth-methods/service/sign.up.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/amorindev/go-tmpl/internal/encryption"
 	"github.com/amorindev/go-tmpl/pkg/app/users/domain"
 	sharedDomain "github.com/amorindev/go-tmpl/pkg/shared/domain"
 )
@@ -21,12 +22,13 @@ func (s *Service) SignUp(ctx context.Context, user *domain.User) error {
 	}
 
 	// Hash the user's password
-	err = user.UserPassAuth.HashPassword()
+	hashPass, err := encryption.HashPassword(user.UserPassAuth.Password)
 	if err != nil {
-		return sharedDomain.ManageError(err, "hashing password")
+		return sharedDomain.ManageError(err, "error hashing password")
 	}
+	user.UserPassAuth.PasswordHash = hashPass
 
-	// Create the  user
+	// Create the user
 	now := time.Now().UTC()
 	user.CreatedAt = &now
 	user.UpdatedAt = &now


### PR DESCRIPTION
Tasks:
- Refactors the authentication flow to rely on the shared encryption package for password hashing.
- Removed the HashPassword method from UserPasswordAuth in domain.user.password.auth.go.
- Updated SignUp service to call encryption.HashPassword for password processing.
- Improves maintainability and avoids duplicate hashing logic.