### PR TITLE
feat #27 (auth-methods/users): add avatar upload and image storage with MinIO

### DIFF
--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -9,12 +9,15 @@ import (
 	"github.com/amorindev/go-tmpl/internal/config"
 	minioClient "github.com/amorindev/go-tmpl/internal/minio"
 	mongoClient "github.com/amorindev/go-tmpl/internal/mongo"
-	"github.com/amorindev/go-tmpl/pkg/app/admin/api/handler"
+	adminHandler "github.com/amorindev/go-tmpl/pkg/app/admin/api/handler"
 	authMethodHandler "github.com/amorindev/go-tmpl/pkg/app/auth-methods/handler"
 	authMethodService "github.com/amorindev/go-tmpl/pkg/app/auth-methods/service"
 	sessionRepository "github.com/amorindev/go-tmpl/pkg/app/session/repository/mongo"
 	sessionService "github.com/amorindev/go-tmpl/pkg/app/session/service"
+	userFileStorage "github.com/amorindev/go-tmpl/pkg/app/users/file-storage/minio"
+	userHandler "github.com/amorindev/go-tmpl/pkg/app/users/handler"
 	userRepository "github.com/amorindev/go-tmpl/pkg/app/users/repository/mongo"
+	userService "github.com/amorindev/go-tmpl/pkg/app/users/service"
 	minioAdapter "github.com/amorindev/go-tmpl/pkg/file-storage/adapter/minio"
 	fileStgService "github.com/amorindev/go-tmpl/pkg/file-storage/service"
 )
@@ -61,14 +64,19 @@ func New() http.Handler {
 		log.Fatal(err)
 	}
 
+	// File Storage
+	userFileStg := userFileStorage.NewUserFileStg(minioC.Client, appEnvs.MinioBucketName, 0)
+
 	// Services
 	authSrv := auth.NewTokenSrv(appEnvs.JWTAccessSecret, appEnvs.JWTRefreshSecret, appEnvs.JWTAccessExpIn, appEnvs.JWTRefreshExpIn, appEnvs.JWTRefreshRememberMeExpIn, appEnvs.JWTIssuer)
 	sessionSrv := sessionService.NewSessionSrv(sessionRepo, authSrv)
-	authMethodSrv := authMethodService.NewAuthMethodSrv(userRepo, sessionSrv)
+	authMethodSrv := authMethodService.NewAuthMethodSrv(userRepo, userFileStg, sessionSrv)
+	userSrv := userService.NewUserSrv(userRepo, userFileStg)
 
 	// Handler
 	// Note: all subsequent handlers should also be registered using v1
 	authMethodHandler.NewAuthMethodHandler(v1, authMethodSrv)
+	userHandler.NewUserHandler(v1, userSrv)
 
 	mux.HandleFunc("GET /ping", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -87,7 +95,7 @@ func New() http.Handler {
 		http.Redirect(w, r, "/v1/admin/home", http.StatusFound)
 	})
 
-	handler.NewAdminHandler(v1, appEnvs.ApiBaseUrl)
+	adminHandler.NewAdminHandler(v1, appEnvs.ApiBaseUrl)
 
 	return mux
 }

--- a/pkg/app/auth-methods/core/core.go
+++ b/pkg/app/auth-methods/core/core.go
@@ -26,6 +26,7 @@ func NewAuthResp(user *userD.User, session *sessionD.Session) *AuthResp {
 			ID:            user.ID.(string),
 			Email:         user.Email,
 			EmailVerified: user.EmailVerified,
+			ImgUrl:        user.ImgUrl,
 			CreatedAt:     user.CreatedAt,
 			UpdatedAt:     user.UpdatedAt,
 		},

--- a/pkg/app/auth-methods/service/service.go
+++ b/pkg/app/auth-methods/service/service.go
@@ -9,13 +9,15 @@ import (
 var _ authMethodP.AuthMethodSrv = &Service{}
 
 type Service struct {
-	UserRepo   userP.UserRepo
-	SessionSrv sessionP.SessionSrv
+	UserRepo    userP.UserRepo
+	UserFileStg userP.UserFileStg
+	SessionSrv  sessionP.SessionSrv
 }
 
-func NewAuthMethodSrv(userRepo userP.UserRepo, sessionSrv sessionP.SessionSrv) *Service {
+func NewAuthMethodSrv(userRepo userP.UserRepo, userFileStg userP.UserFileStg, sessionSrv sessionP.SessionSrv) *Service {
 	return &Service{
-		UserRepo:   userRepo,
-		SessionSrv: sessionSrv,
+		UserRepo:    userRepo,
+		UserFileStg: userFileStg,
+		SessionSrv:  sessionSrv,
 	}
 }

--- a/pkg/app/auth-methods/service/sign_in.go
+++ b/pkg/app/auth-methods/service/sign_in.go
@@ -25,6 +25,15 @@ func (s *Service) SignIn(ctx context.Context, email string, password string, rem
 		return nil, nil, dShared.ManageError(err, "")
 	}
 
+	// If the user has an image path, retrieve the image URL and set it
+	if user.ImgPath != nil {
+		url, err := s.UserFileStg.GetImage(ctx, *user.ImgPath)
+		if err != nil {
+			return nil, nil, dShared.ManageError(err, "")
+		}
+		user.ImgUrl = &url
+	}
+
 	// Create session
 	session := sessionD.NewSession(user.ID.(string), rememberMe)
 

--- a/pkg/app/users/core/core.user.go
+++ b/pkg/app/users/core/core.user.go
@@ -11,6 +11,7 @@ type UserCore struct {
 	ID            string     `json:"id"`
 	Email         string     `json:"email"`
 	EmailVerified bool       `json:"email_verified"`
+	ImgUrl        *string    `json:"img_url"`
 	CreatedAt     *time.Time `json:"created_at"`
 	UpdatedAt     *time.Time `json:"updated_at"`
 }

--- a/pkg/app/users/domain/domain.user.go
+++ b/pkg/app/users/domain/domain.user.go
@@ -12,12 +12,14 @@ type User struct {
 	Email         string                   `bson:"email"`
 	EmailVerified bool                     `bson:"email_verified"`
 	IsActive      bool                     `bson:"is_active"`
+	ImgUrl        *string                  `bson:"-"`
+	ImgPath       *string                  `bson:"img_path"`
 	UserPassAuth  *domain.UserPasswordAuth `bson:"pass_method"`
 	CreatedAt     *time.Time               `bson:"created_at"`
 	UpdatedAt     *time.Time               `bson:"updated_at"`
 }
 
-func NewUser(email string, password string) *User{
+func NewUser(email string, password string) *User {
 	return &User{
 		Email: email,
 		UserPassAuth: &domain.UserPasswordAuth{

--- a/pkg/app/users/file-storage/minio/file_storage.go
+++ b/pkg/app/users/file-storage/minio/file_storage.go
@@ -1,0 +1,27 @@
+package minio
+
+import (
+	"time"
+
+	"github.com/amorindev/go-tmpl/pkg/app/users/port"
+	"github.com/minio/minio-go/v7"
+)
+
+var _ port.UserFileStg = &FileStorage{}
+
+type FileStorage struct {
+	MinioClient *minio.Client
+	BucketName  string
+	ExpTime     time.Duration
+}
+
+func NewUserFileStg(client *minio.Client, bucketName string, expTime time.Duration) *FileStorage {
+	if expTime == 0 {
+		expTime = time.Hour * 24 * 7
+	}
+	return &FileStorage{
+		MinioClient: client,
+		BucketName:  bucketName,
+		ExpTime:     expTime,
+	}
+}

--- a/pkg/app/users/file-storage/minio/get_image.go
+++ b/pkg/app/users/file-storage/minio/get_image.go
@@ -1,0 +1,22 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+
+func (fs *FileStorage) GetImage(ctx context.Context, imgPath string) (string, error) {
+	// Set request parameters for content-disposition.
+	reqParams := make(url.Values)
+
+	// Generates a presigned url which expires in a day.
+	presignedURL, err := fs.MinioClient.PresignedGetObject(ctx, fs.BucketName, imgPath, fs.ExpTime, reqParams)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate presigned URL for user image %q in bucket %q: %w", imgPath, fs.BucketName, err)
+	}
+
+	return presignedURL.String(), nil
+}
+

--- a/pkg/app/users/file-storage/minio/upload_image.go
+++ b/pkg/app/users/file-storage/minio/upload_image.go
@@ -1,0 +1,22 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/minio/minio-go/v7"
+)
+
+func (fs *FileStorage) UploadImage(ctx context.Context, imgPath string, file io.Reader, contentType string) error {
+	options := minio.PutObjectOptions{
+		ContentType: contentType,
+	}
+
+	_, err := fs.MinioClient.PutObject(ctx, fs.BucketName, imgPath, file, -1, options)
+	if err != nil {
+		return fmt.Errorf("failed to upload user image %q to bucket %q: %w", imgPath, fs.BucketName, err)
+	}
+
+	return nil
+}

--- a/pkg/app/users/handler/handler.go
+++ b/pkg/app/users/handler/handler.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/app/users/port"
+)
+
+type Handler struct {
+	UserSrv port.UserSrv
+}
+
+func NewUserHandler(server *http.ServeMux, userSrv port.UserSrv) *Handler {
+	h := &Handler{
+		UserSrv: userSrv,
+	}
+
+	server.HandleFunc("POST /users/{userId}/avatar", h.UploadAvatar)
+
+	return h
+}

--- a/pkg/app/users/handler/upload_avatar.go
+++ b/pkg/app/users/handler/upload_avatar.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("userId")
+
+	if userID == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing user id"))
+		return
+	}
+
+	err := r.ParseMultipartForm(20 << 20) // 20MB
+	if err != nil {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "invalid form"))
+		return
+	}
+
+	file, header, err := r.FormFile("image")
+	if err != nil {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "error retrieving file"))
+		return
+	}
+	defer file.Close()
+
+	// Proper Content-Type detection
+	fileBuffer := make([]byte, 512)
+	_, err = file.Read(fileBuffer)
+	if err != nil {
+		msg := "failed to read uploaded file for content-type detection"
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInternalServerError, msg))
+		return
+	}
+	fileType := http.DetectContentType(fileBuffer)
+
+	// Reset file reader position
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		msg := "failed to reset file pointer after reading"
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInternalServerError, msg))
+		return
+	}
+
+	allowedTypes := map[string]bool{
+		"image/jpeg":    true,
+		"image/png":     true,
+		"image/gif":     true,
+		"image/webp":    true,
+		"image/avif":    true,
+		"image/svg+xml": true,
+	}
+
+	if !allowedTypes[fileType] {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInternalServerError, "invalid image format"))
+		return
+	}
+
+	err = h.UserSrv.UploadAvatar(context.Background(), header.Filename, file, userID, fileType)
+	if err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/app/users/port/ports.user.go
+++ b/pkg/app/users/port/ports.user.go
@@ -2,6 +2,8 @@ package port
 
 import (
 	"context"
+	"io"
+	"time"
 
 	"github.com/amorindev/go-tmpl/pkg/app/users/domain"
 )
@@ -9,5 +11,16 @@ import (
 type UserRepo interface {
 	Insert(ctx context.Context, user *domain.User) error
 	FindByEmail(ctx context.Context, email string) (*domain.User, error)
+	Exists(ctx context.Context, id string) (bool, error)
 	ExistsByEmail(ctx context.Context, email string) (bool, error)
+	UpdateAvatarPath(ctx context.Context, userID string, imgPath string, updatedAt time.Time) error
+}
+
+type UserSrv interface {
+	UploadAvatar(ctx context.Context, path string, file io.Reader, userID string, contentType string) error
+}
+
+type UserFileStg interface {
+	GetImage(ctx context.Context, imgPath string) (string, error)
+	UploadImage(ctx context.Context, imgPath string, file io.Reader, contentType string) error
 }

--- a/pkg/app/users/repository/mongo/exists.go
+++ b/pkg/app/users/repository/mongo/exists.go
@@ -1,0 +1,26 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// Exists checks if a user with the given id already exists in the collection.
+func (r *Repository) Exists(ctx context.Context, id string) (bool, error) {
+	oID, err := bson.ObjectIDFromHex(id)
+	if err != nil {
+		return false, fmt.Errorf("%w: failed to convert userID to ObjectID :%w", domain.ErrIncorrectID, err)
+	}
+
+	filter := bson.M{"_id": oID}
+
+	count, err := r.Collection.CountDocuments(ctx, filter)
+	if err != nil {
+		return false, fmt.Errorf("error checking user existence: %s", err.Error())
+	}
+
+	return count > 0, nil
+}

--- a/pkg/app/users/repository/mongo/update_avatar_path.go
+++ b/pkg/app/users/repository/mongo/update_avatar_path.go
@@ -1,0 +1,31 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (r *Repository) UpdateAvatarPath(ctx context.Context, userID, imgPath string, updatedAt time.Time) error {
+	oID, err := bson.ObjectIDFromHex(userID)
+	if err != nil {
+		return fmt.Errorf("%w: failed to convert userID to ObjectID :%w", domain.ErrIncorrectID, err)
+	}
+
+	filter := bson.M{"_id": oID}
+	update := bson.M{"$set": bson.M{"img_path": imgPath, "updated_at": updatedAt}}
+
+	result, err := r.Collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to update user avatar path in database: %w", err)
+	}
+
+	if result.MatchedCount == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}

--- a/pkg/app/users/service/service.go
+++ b/pkg/app/users/service/service.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"github.com/amorindev/go-tmpl/pkg/app/users/port"
+)
+
+var _ port.UserSrv = &Service{}
+
+type Service struct {
+	UserRepo   port.UserRepo
+	UserFileStg port.UserFileStg
+}
+
+func NewUserSrv(userRepo port.UserRepo, userFileStg port.UserFileStg) *Service {
+	return &Service{
+		UserRepo:   userRepo,
+		UserFileStg: userFileStg,
+	}
+}

--- a/pkg/app/users/service/upload_avatar.go
+++ b/pkg/app/users/service/upload_avatar.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"time"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) UploadAvatar(ctx context.Context, img string, file io.Reader, userID string, contentType string) error {
+	exists, err := s.UserRepo.Exists(ctx, userID)
+	if err != nil {
+		return domain.ManageError(err, "")
+	}
+
+	if !exists {
+		return domain.ManageError(domain.ErrNotFound, "")
+	}
+
+	path := fmt.Sprintf("users/%s%s", userID, filepath.Ext(img))
+
+	err = s.UserFileStg.UploadImage(ctx, path, file, contentType)
+	if err != nil {
+		return domain.ManageError(err, "")
+	}
+
+	now := time.Now().UTC()
+	err = s.UserRepo.UpdateAvatarPath(ctx, userID, path, now)
+	if err != nil {
+		return domain.ManageError(err, "")
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Description
Adds user avatar upload and retrieval using MinIO.

Tasks:
- New UserFileStg (MinIO) for uploading and generating presigned URLs.
- New endpoint: POST /users/{userId}/avatar with validation (JPEG/PNG/GIF/WebP/AVIF/SVG, max 20 MB).
- User model updated with ImgPath (DB) and ImgUrl (response).
- AuthMethodService now returns the avatar URL on sign-in if available.
- Server initialization injects UserFileStg into user and auth services.

Securely stores user avatars and serves them via expiring presigned URLs.

<img width="935" height="449" alt="image" src="https://github.com/user-attachments/assets/0694ff52-6e22-4ff6-a3f9-cfe56267df5d" />
<img width="934" height="597" alt="image" src="https://github.com/user-attachments/assets/d5e3cab0-da29-49e4-9186-7f3388240871" />

Close #27 